### PR TITLE
Added var.additional_ports to forward additional ports to app

### DIFF
--- a/listener.tf
+++ b/listener.tf
@@ -22,3 +22,28 @@ resource "aws_lb_listener" "this" {
     target_group_arn = aws_lb_target_group.this.arn
   }
 }
+
+resource "aws_security_group_rule" "additional-from-world" {
+  for_each = var.additional_ports
+
+  security_group_id = local.app_security_group_id
+  type              = "ingress"
+  protocol          = "-1"
+  from_port         = each.value
+  to_port           = each.value
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_lb_listener" "additional" {
+  for_each = var.additional_ports
+
+  load_balancer_arn = aws_lb.this.arn
+  protocol          = var.protocol
+  port              = each.value
+  tags              = local.tags
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.this.arn
+  }
+}

--- a/target-group.tf
+++ b/target-group.tf
@@ -20,3 +20,30 @@ resource "aws_lb_target_group" "this" {
     protocol            = var.protocol
   }
 }
+
+resource "aws_lb_target_group" "additional" {
+  for_each = var.additional_ports
+
+  name                 = "${local.resource_name}-${each.value}"
+  port                 = each.value
+  protocol             = var.protocol
+  target_type          = "ip"
+  vpc_id               = local.vpc_id
+  deregistration_delay = 10
+  tags                 = local.tags
+
+  health_check {
+    // Perform health check on app's primary port
+    port                = local.port
+    interval            = var.health_check_interval
+    healthy_threshold   = var.health_check_healthy_threshold
+    unhealthy_threshold = var.health_check_unhealthy_threshold
+    enabled             = var.health_check_enabled
+    timeout             = var.health_check_timeout
+    protocol            = var.protocol
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -28,6 +28,15 @@ EOF
   }
 }
 
+variable "additional_ports" {
+  type        = set(number)
+  default     = []
+  description = <<EOF
+By default, the load balancer will listen on the application's `port`.
+This variable allows you to forward other ports to your container through the load balancer.
+EOF
+}
+
 variable "health_check_enabled" {
   description = "Enable and configure health checking for the service from the load balancer."
   type        = bool


### PR DESCRIPTION
In some scenarios, users need to forward port 80 and port 443.
To resolve this, a user would configure the app's `port=80` and configure this capability with `additional_ports=[443]`.

This PR adds support for these scenarios.